### PR TITLE
feature: Delayed background rendering

### DIFF
--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -342,20 +342,18 @@ Viewer.prototype = {
       for (var i = 0; i < images.length; i++) {
         var image = images[i];
         image.addEventListener('error', function() {
-          console.debug('image load error, retry in 1s');
+          console.debug('image load error, retry in 1s', image);
           setTimeout(function() {
-            console.debug('retrying image load');
+            console.debug('retrying image load', image);
             var tmp = image.src;
             image.src = '';
             image.src = tmp;
-            console.debug('image src reset to ' + tmp);
           }, 1000);
         });
-        console.debug('image reload');
+        console.debug('image reload', image);
         var tmp = image.src;
         image.src = '';
         image.src = tmp;
-        console.debug('image src reset to ' + tmp);
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -348,12 +348,14 @@ Viewer.prototype = {
             var tmp = image.src;
             image.src = '';
             image.src = tmp;
+            console.debug('image src reset to ' + tmp);
           }, 1000);
         });
         console.debug('image reload');
         var tmp = image.src;
         image.src = '';
         image.src = tmp;
+        console.debug('image src reset to ' + tmp);
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -346,12 +346,16 @@ Viewer.prototype = {
             console.debug('image load error, retry in 1s', image);
             setTimeout(function() {
               console.debug('retrying image load', image);
-              image.src = image.src;
+              var tmp = image.src;
+              image.src = '';
+              image.src = tmp;
             }, 1000);
           });
         })(image);
         console.debug('image reload', image);
-        image.src = image.src;
+        var tmp = image.src;
+        image.src = '';
+        image.src = tmp;
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -343,14 +343,11 @@ Viewer.prototype = {
         var image = images[i];
         (function(image) {
           image.addEventListener('error', function() {
-            console.debug('image load error, retry in 1s', image);
             setTimeout(function() {
-              console.debug('retrying image load', image);
               image.src = image.src;
             }, 1000);
           });
         })(image);
-        console.debug('image reload', image);
         image.src = image.src;
       }
     }

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -335,22 +335,6 @@ Viewer.prototype = {
 
     this.initialize_radio_button();
     this.render();
-
-    {
-      // deal with delayed image loading
-      var images = document.getElementsByTagName('img'); 
-      for (var i = 0; i < images.length; i++) {
-        var image = images[i];
-        (function(image) {
-          image.addEventListener('error', function() {
-            setTimeout(function() {
-              image.src = image.src;
-            }, 1000);
-          });
-        })(image);
-        image.src = image.src;
-      }
-    }
   },
 
   /*

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -341,19 +341,17 @@ Viewer.prototype = {
       var images = document.getElementsByTagName('img'); 
       for (var i = 0; i < images.length; i++) {
         var image = images[i];
-        image.addEventListener('error', function() {
-          console.debug('image load error, retry in 1s', image);
-          setTimeout(function() {
-            console.debug('retrying image load', image);
-            var tmp = image.src;
-            image.src = '';
-            image.src = tmp;
-          }, 1000);
-        });
+        (function(image) {
+          image.addEventListener('load', function() {
+            console.debug('image load error, retry in 1s', image);
+            setTimeout(function() {
+              console.debug('retrying image load', image);
+              image.src = image.src;
+            }, 1000);
+          });
+        })(image);
         console.debug('image reload', image);
-        var tmp = image.src;
-        image.src = '';
-        image.src = tmp;
+        image.src = image.src;
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -342,12 +342,15 @@ Viewer.prototype = {
       for (var i = 0; i < images.length; i++) {
         var image = images[i];
         image.addEventListener('error', function() {
+          console.debug('image load error, retry in 1s');
           setTimeout(function() {
+            console.debug('retrying image load');
             var tmp = image.src;
             image.src = '';
             image.src = tmp;
           }, 1000);
         });
+        console.debug('image reload');
         var tmp = image.src;
         image.src = '';
         image.src = tmp;

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -340,12 +340,13 @@ Viewer.prototype = {
       // deal with image reloading
       var images = document.getElementsByTagName('img'); 
       for (var i = 0; i < images.length; i++) {
-        images[i].addEventListener('error', function() {
+        var image = images[i];
+        image.addEventListener('error', function() {
           setTimeout(function() {
-            images[i].src = images[i].src;
+            image.src = image.src;
           }, 1000);
         });
-        images[i].src = images[i].src;
+        image.src = image.src;
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -337,18 +337,18 @@ Viewer.prototype = {
     this.render();
 
     {
-      // deal with image reloading
+      // deal with delayed image loading
       var images = document.getElementsByTagName('img'); 
       for (var i = 0; i < images.length; i++) {
         var image = images[i];
         image.addEventListener('error', function() {
           setTimeout(function() {
-            tmp = image.src;
+            var tmp = image.src;
             image.src = '';
             image.src = tmp;
           }, 1000);
         });
-        tmp = image.src;
+        var tmp = image.src;
         image.src = '';
         image.src = tmp;
       }

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -343,10 +343,14 @@ Viewer.prototype = {
         var image = images[i];
         image.addEventListener('error', function() {
           setTimeout(function() {
-            image.src = image.src;
+            tmp = image.src;
+            image.src = '';
+            image.src = tmp;
           }, 1000);
         });
-        image.src = image.src;
+        tmp = image.src;
+        image.src = '';
+        image.src = tmp;
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -342,20 +342,16 @@ Viewer.prototype = {
       for (var i = 0; i < images.length; i++) {
         var image = images[i];
         (function(image) {
-          image.addEventListener('load', function() {
+          image.addEventListener('error', function() {
             console.debug('image load error, retry in 1s', image);
             setTimeout(function() {
               console.debug('retrying image load', image);
-              var tmp = image.src;
-              image.src = '';
-              image.src = tmp;
+              image.src = image.src;
             }, 1000);
           });
         })(image);
         console.debug('image reload', image);
-        var tmp = image.src;
-        image.src = '';
-        image.src = tmp;
+        image.src = image.src;
       }
     }
   },

--- a/pdf2htmlEX/share/pdf2htmlEX.js.in
+++ b/pdf2htmlEX/share/pdf2htmlEX.js.in
@@ -335,6 +335,19 @@ Viewer.prototype = {
 
     this.initialize_radio_button();
     this.render();
+
+    {
+      // deal with image reloading
+      var images = document.getElementsByTagName('img'); 
+      for (var i = 0; i < images.length; i++) {
+        images[i].addEventListener('error', function() {
+          setTimeout(function() {
+            images[i].src = images[i].src;
+          }, 1000);
+        });
+        images[i].src = images[i].src;
+      }
+    }
   },
 
   /*

--- a/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -130,11 +130,10 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     if (doc->getPageRotate(pageno) == 90 || doc->getPageRotate(pageno) == 270)
         std::swap(page_height, page_width);
 
-    
-    std::string tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
-    std::string fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
 
-    surface = cairo_svg_surface_create(tmp_fn.c_str(), page_width * param.actual_dpi / DEFAULT_DPI, page_height * param.actual_dpi / DEFAULT_DPI);
+    surface = cairo_svg_surface_create((const char *)tmp_fn, page_width * param.actual_dpi / DEFAULT_DPI, page_height * param.actual_dpi / DEFAULT_DPI);
     cairo_svg_surface_restrict_to_version(surface, CAIRO_SVG_VERSION_1_2);
     cairo_surface_set_fallback_resolution(surface, param.actual_dpi, param.actual_dpi);
 
@@ -174,7 +173,7 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     {
         int n = 0;
         char c;
-        ifstream svgfile(tmp_fn);
+        ifstream svgfile((const char *)tmp_fn);
         //count of '<' in the file should be an approximation of node count.
         while(svgfile >> c)
         {
@@ -191,10 +190,10 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     for (auto id : bitmaps_in_current_page)
         ++bitmaps_ref_count[id];
 
-    std::rename(tmp_fn.c_str(), fn.c_str());
+    std::rename((const char *)tmp_fn, (const char *)fn);
 
     if(param.embed_image)
-        html_renderer->tmp_files.add(fn);
+        html_renderer->tmp_files.add((const char *)fn);
 
     return true;
 }

--- a/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -130,10 +130,9 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     if (doc->getPageRotate(pageno) == 90 || doc->getPageRotate(pageno) == 270)
         std::swap(page_height, page_width);
 
-    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.svg", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno);
     auto fn = html_renderer->str_fmt("%s/bg%x.svg", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno);
 
-    surface = cairo_svg_surface_create((const char *)tmp_fn, page_width * param.actual_dpi / DEFAULT_DPI, page_height * param.actual_dpi / DEFAULT_DPI);
+    surface = cairo_svg_surface_create((const char *)fn, page_width * param.actual_dpi / DEFAULT_DPI, page_height * param.actual_dpi / DEFAULT_DPI);
     cairo_svg_surface_restrict_to_version(surface, CAIRO_SVG_VERSION_1_2);
     cairo_surface_set_fallback_resolution(surface, param.actual_dpi, param.actual_dpi);
 
@@ -173,7 +172,7 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     {
         int n = 0;
         char c;
-        ifstream svgfile((const char *)tmp_fn);
+        ifstream svgfile((const char *)fn);
         //count of '<' in the file should be an approximation of node count.
         while(svgfile >> c)
         {
@@ -189,8 +188,6 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     // the svg file is actually used, so add its bitmaps' ref count.
     for (auto id : bitmaps_in_current_page)
         ++bitmaps_ref_count[id];
-
-    std::rename((const char *)tmp_fn, (const char *)fn);
 
     if(param.embed_image)
         html_renderer->tmp_files.add((const char *)fn);

--- a/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/CairoBackgroundRenderer.cc
@@ -130,8 +130,8 @@ bool CairoBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     if (doc->getPageRotate(pageno) == 90 || doc->getPageRotate(pageno) == 270)
         std::swap(page_height, page_width);
 
-    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
-    auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.svg", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno);
+    auto fn = html_renderer->str_fmt("%s/bg%x.svg", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno);
 
     surface = cairo_svg_surface_create((const char *)tmp_fn, page_width * param.actual_dpi / DEFAULT_DPI, page_height * param.actual_dpi / DEFAULT_DPI);
     cairo_svg_surface_restrict_to_version(surface, CAIRO_SVG_VERSION_1_2);

--- a/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -114,7 +114,6 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
 
     auto * bitmap = getBitmap();
 
-    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
     auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
 
     SplashImageFileFormat splashImageFileFormat;
@@ -125,11 +124,9 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     else
         throw string("Image format not supported: ") + format;
 
-    SplashError e = bitmap->writeImgFile(splashImageFileFormat, (const char *)tmp_fn, param.actual_dpi, param.actual_dpi);
+    SplashError e = bitmap->writeImgFile(splashImageFileFormat, (const char *)fn, param.actual_dpi, param.actual_dpi);
     if (e != splashOk)
         throw string("Cannot write background image. SplashErrorCode: ") + std::to_string(e);
-
-    std::rename((const char *)tmp_fn, (const char *)fn);
 
     if(param.embed_image)
         html_renderer->tmp_files.add((const char *)fn);

--- a/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -114,9 +114,8 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
 
     auto * bitmap = getBitmap();
 
-    auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
-    if(param.embed_image)
-        html_renderer->tmp_files.add((const char *)fn);
+    std::string tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    std::string fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
 
     SplashImageFileFormat splashImageFileFormat;
     if(format == "png")
@@ -126,9 +125,14 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     else
         throw string("Image format not supported: ") + format;
 
-    SplashError e = bitmap->writeImgFile(splashImageFileFormat, (const char *)fn, param.actual_dpi, param.actual_dpi);
+    SplashError e = bitmap->writeImgFile(splashImageFileFormat, tmp_fn.c_str(), param.actual_dpi, param.actual_dpi);
     if (e != splashOk)
         throw string("Cannot write background image. SplashErrorCode: ") + std::to_string(e);
+
+    std::rename(tmp_fn.c_str(), fn.c_str());
+
+    if(param.embed_image)
+        html_renderer->tmp_files.add(fn);
 
     return true;
 }

--- a/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
+++ b/pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc
@@ -114,8 +114,8 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
 
     auto * bitmap = getBitmap();
 
-    std::string tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
-    std::string fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    auto tmp_fn = html_renderer->str_fmt("%s/tmp_bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+    auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
 
     SplashImageFileFormat splashImageFileFormat;
     if(format == "png")
@@ -125,14 +125,14 @@ bool SplashBackgroundRenderer::render_page(PDFDoc * doc, int pageno)
     else
         throw string("Image format not supported: ") + format;
 
-    SplashError e = bitmap->writeImgFile(splashImageFileFormat, tmp_fn.c_str(), param.actual_dpi, param.actual_dpi);
+    SplashError e = bitmap->writeImgFile(splashImageFileFormat, (const char *)tmp_fn, param.actual_dpi, param.actual_dpi);
     if (e != splashOk)
         throw string("Cannot write background image. SplashErrorCode: ") + std::to_string(e);
 
-    std::rename(tmp_fn.c_str(), fn.c_str());
+    std::rename((const char *)tmp_fn, (const char *)fn);
 
     if(param.embed_image)
-        html_renderer->tmp_files.add(fn);
+        html_renderer->tmp_files.add((const char *)fn);
 
     return true;
 }

--- a/pdf2htmlEX/src/CoveredTextDetector.cc
+++ b/pdf2htmlEX/src/CoveredTextDetector.cc
@@ -14,6 +14,10 @@
 
 namespace pdf2htmlEX {
 
+CoveredTextDetector::CoveredTextDetector()
+{
+}
+
 CoveredTextDetector::CoveredTextDetector(Param & param): param(&param)
 {
 }

--- a/pdf2htmlEX/src/CoveredTextDetector.cc
+++ b/pdf2htmlEX/src/CoveredTextDetector.cc
@@ -14,7 +14,7 @@
 
 namespace pdf2htmlEX {
 
-CoveredTextDetector::CoveredTextDetector(Param & param): param(param)
+CoveredTextDetector::CoveredTextDetector(Param & param): param(&param)
 {
 }
 
@@ -41,10 +41,10 @@ void CoveredTextDetector::add_char_bbox_clipped(cairo_t *cairo, double * bbox, i
     char_pts_visible.push_back(pts_visible);
 
     // DCRH: Hide if no points are visible, or if some points are visible and correct_text_visibility == 2
-    if (pts_visible == 0 || param.correct_text_visibility == 2) {
+    if (pts_visible == 0 || param->correct_text_visibility == 2) {
         chars_covered.push_back(true);
-        if (pts_visible > 0 && param.correct_text_visibility == 2) {
-            param.actual_dpi = std::min(param.text_dpi, param.max_dpi); // Char partially covered so increase background resolution
+        if (pts_visible > 0 && param->correct_text_visibility == 2) {
+            param->actual_dpi = std::min(param->text_dpi, param->max_dpi); // Char partially covered so increase background resolution
         }
     } else {
         chars_covered.push_back(false);
@@ -98,13 +98,13 @@ printf("pts_visible=%x\n", pts_visible);
 printf("pts_visible=%x\n", pts_visible);
 #endif
             char_pts_visible[i] = pts_visible;
-            if (pts_visible == 0 || (pts_visible != (1|2|4|8) && param.correct_text_visibility == 2)) {
+            if (pts_visible == 0 || (pts_visible != (1|2|4|8) && param->correct_text_visibility == 2)) {
 #ifdef DEBUG
 printf("Char covered\n");
 #endif
                 chars_covered[i] = true;
-                if (pts_visible > 0 && param.correct_text_visibility == 2) { // Partially visible text => increase rendering DPI
-                    param.actual_dpi = std::min(param.text_dpi, param.max_dpi);
+                if (pts_visible > 0 && param->correct_text_visibility == 2) { // Partially visible text => increase rendering DPI
+                    param->actual_dpi = std::min(param->text_dpi, param->max_dpi);
                 }
             }
         } else {

--- a/pdf2htmlEX/src/CoveredTextDetector.h
+++ b/pdf2htmlEX/src/CoveredTextDetector.h
@@ -60,7 +60,7 @@ private:
     // x00, y00, x01, y01; x10, y10, x11, y11;...
     std::vector<double> char_bboxes;
     std::vector<int> char_pts_visible;
-    Param & param;
+    Param * param;
 };
 
 }

--- a/pdf2htmlEX/src/CoveredTextDetector.h
+++ b/pdf2htmlEX/src/CoveredTextDetector.h
@@ -21,6 +21,7 @@ namespace pdf2htmlEX {
 class CoveredTextDetector
 {
 public:
+    CoveredTextDetector();
 
     CoveredTextDetector(Param & param);
 

--- a/pdf2htmlEX/src/HTMLRenderer/HTMLRenderer.h
+++ b/pdf2htmlEX/src/HTMLRenderer/HTMLRenderer.h
@@ -381,6 +381,11 @@ protected:
 
     CoveredTextDetector covered_text_detector;
     DrawingTracer tracer;
+
+    struct PageCache {
+        CoveredTextDetector covered_text_detector;
+    };
+    std::unordered_map<int, PageCache> page_cache;
 };
 
 } //namespace pdf2htmlEX

--- a/pdf2htmlEX/src/HTMLRenderer/HTMLRenderer.h
+++ b/pdf2htmlEX/src/HTMLRenderer/HTMLRenderer.h
@@ -80,6 +80,8 @@ struct HTMLRenderer : OutputDev
 
     void process(PDFDoc * doc);
 
+    bool renderPage(PDFDoc * doc, int pageno);
+
     ////////////////////////////////////////////////////
     // OutputDev interface
     ////////////////////////////////////////////////////

--- a/pdf2htmlEX/src/HTMLRenderer/general.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/general.cc
@@ -200,7 +200,7 @@ bool HTMLRenderer::renderPage(PDFDoc *doc, int pageno)
         return false;
     }
 
-    if (page_cache.find(pageno) != page_cache.end())
+    if (page_cache.find(pageno) == page_cache.end())
     {
         cerr << "Page number " << pageno << " not found in page cache" << endl;
         return false;

--- a/pdf2htmlEX/src/HTMLRenderer/general.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/general.cc
@@ -228,13 +228,6 @@ void HTMLRenderer::setDefaultCTM(const double *ctm)
 
 void HTMLRenderer::startPage(int pageNum, GfxState *state, XRef * xref)
 {
-    if (param.delay_background && this->pageNum > 0)
-    {
-        page_cache[this->pageNum] = {
-            .covered_text_detector = covered_text_detector,
-        };
-    }
-
     covered_text_detector.reset();
     tracer.reset(state);
 
@@ -338,6 +331,13 @@ void HTMLRenderer::endPage() {
     if(param.split_pages)
     {
         f_pages.fs << "</div>" << endl;
+    }
+
+    if (param.delay_background)
+    {
+        page_cache[this->pageNum] = {
+            .covered_text_detector = covered_text_detector,
+        };
     }
 }
 

--- a/pdf2htmlEX/src/HTMLRenderer/general.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/general.cc
@@ -183,9 +183,6 @@ void HTMLRenderer::process(PDFDoc *doc)
 
     post_process();
 
-    bg_renderer = nullptr;
-    fallback_bg_renderer = nullptr;
-
     if(param.quiet == 0)
         cerr << endl;
 }

--- a/pdf2htmlEX/src/HTMLRenderer/general.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/general.cc
@@ -189,13 +189,13 @@ void HTMLRenderer::process(PDFDoc *doc)
 
 bool HTMLRenderer::renderPage(PDFDoc *doc, int pageno)
 {
-    if (bg_renderer->render_page(cur_doc, pageNum))
+    if (bg_renderer->render_page(cur_doc, pageno))
     {
         return true;
     }
     else if (fallback_bg_renderer)
     {
-        if (fallback_bg_renderer->render_page(cur_doc, pageNum))
+        if (fallback_bg_renderer->render_page(cur_doc, pageno))
             return true;
     }
 

--- a/pdf2htmlEX/src/HTMLRenderer/general.cc
+++ b/pdf2htmlEX/src/HTMLRenderer/general.cc
@@ -190,6 +190,21 @@ void HTMLRenderer::process(PDFDoc *doc)
         cerr << endl;
 }
 
+bool HTMLRenderer::renderPage(PDFDoc *doc, int pageno)
+{
+    if (bg_renderer->render_page(cur_doc, pageNum))
+    {
+        return true;
+    }
+    else if (fallback_bg_renderer)
+    {
+        if (fallback_bg_renderer->render_page(cur_doc, pageNum))
+            return true;
+    }
+
+    return false;
+}
+
 void HTMLRenderer::setDefaultCTM(const double *ctm)
 {
     memcpy(default_ctm, ctm, sizeof(default_ctm));
@@ -243,14 +258,21 @@ void HTMLRenderer::endPage() {
 
     if(param.process_nontext)
     {
-        if (bg_renderer->render_page(cur_doc, pageNum))
+        if (param.delay_background)
         {
             bg_renderer->embed_image(pageNum);
         }
-        else if (fallback_bg_renderer)
+        else
         {
-            if (fallback_bg_renderer->render_page(cur_doc, pageNum))
-                fallback_bg_renderer->embed_image(pageNum);
+            if (bg_renderer->render_page(cur_doc, pageNum))
+            {
+                bg_renderer->embed_image(pageNum);
+            }
+            else if (fallback_bg_renderer)
+            {
+                if (fallback_bg_renderer->render_page(cur_doc, pageNum))
+                    fallback_bg_renderer->embed_image(pageNum);
+            }
         }
     }
 

--- a/pdf2htmlEX/src/Param.h
+++ b/pdf2htmlEX/src/Param.h
@@ -46,6 +46,7 @@ struct Param
     int printing;
     int fallback;
     int tmp_file_size_limit;
+    int delay_background;
 
     // fonts
     int embed_external_font;


### PR DESCRIPTION
Currently it is only possible to process the whole PDF at once which can take a significant amount of time for big files. One of the biggest time consumers is rendering of the background images, which is practically just rendering a single page. This (should) be independent from generating the HTML and from rendering other pages.

In this PR I introduce a new config param `delay_background` which generates the HTML for the background images as if they have been rendered already but then lets the user call a new `HTMLRenderer::renderPage` function themselves for the actual rendering and storing of the image.

This required to change `SplashBackgroundRenderer` a bit as it assumed the background image might not be the full page. I did not see a good reason for this (? potential problems might be discovered later) and changed it so it always expects a fully rendered background image. This also conflicts with the fallback renderer as we only know that the normal renderer failed after we tried. But I believe the fallback is only a workaround which we should not rely on in the best case anyways.