### PR TITLE
fix: Only light mode

### DIFF
--- a/pdf2htmlEX/share/manifest
+++ b/pdf2htmlEX/share/manifest
@@ -22,6 +22,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="generator" content="pdf2htmlEX"/>
+<meta name="color-scheme" content="only light"/>
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
 """
 


### PR DESCRIPTION
Potentially fixes https://github.com/opendocument-app/OpenDocument.droid/issues/300

Reference https://stackoverflow.com/questions/72922557/light-dark-mode-in-html-without-css-only-html